### PR TITLE
feat: customer managed key

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ The following input variables are optional (have default values):
 
 ### <a name="input_customer_managed_key"></a> [customer\_managed\_key](#input\_customer\_managed\_key)
 
-Description: n/a
+Description: An object containing the following attributes:
+
+- `key_vault_resource_id` - The resource ID of the key vault.
+- `key_name` - The name of the key.
+- `key_version` - (Optional) The version of the key. If not provided, the latest version will be used.
+- `user_assigned_identity` - (Optional) An object containing the resource ID of the user assigned identity.
+  - `resource_id` - The resource ID of the user assigned identity.
 
 Type:
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Default: `true`
 
 ### <a name="input_role_assignment_definition_scope"></a> [role\_assignment\_definition\_scope](#input\_role\_assignment\_definition\_scope)
 
-Description: The scope at which the role assignments should be created.
+Description: The scope at which the role assignments should be created. Used to look up role definitions by role name.
 
 Must be specified when `role_assignments` are defined.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The following resources are used by this module:
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/resources/telemetry) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/client_config) (data source)
+- [azapi_resource.customer_managed_key_identity](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/resource) (data source)
 - [azapi_resource_list.role_definitions](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/resource_list) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/data-sources/module_source) (data source)
 
@@ -72,6 +73,33 @@ No required inputs.
 ## Optional Inputs
 
 The following input variables are optional (have default values):
+
+### <a name="input_customer_managed_key"></a> [customer\_managed\_key](#input\_customer\_managed\_key)
+
+Description: n/a
+
+Type:
+
+```hcl
+object({
+    key_vault_resource_id = string
+    key_name              = string
+    key_version           = optional(string, null)
+    user_assigned_identity = optional(object({
+      resource_id = string
+    }), null)
+  })
+```
+
+Default: `null`
+
+### <a name="input_customer_managed_key_key_vault_domain"></a> [customer\_managed\_key\_key\_vault\_domain](#input\_customer\_managed\_key\_key\_vault\_domain)
+
+Description: The domain name for the key vault. Default is `vault.azure.net`.
+
+Type: `string`
+
+Default: `"vault.azure.net"`
 
 ### <a name="input_diagnostic_settings"></a> [diagnostic\_settings](#input\_diagnostic\_settings)
 
@@ -205,7 +233,7 @@ map(object({
     }), null)
     tags                                    = optional(map(string), null)
     subnet_resource_id                      = string
-    subresource_name                        = string # NOTE: `subresource_name` can be excluded if the resource does not support multiple sub resource types (e.g. storage account supports blob, queue, etc)
+    subresource_name                        = optional(string, null)
     private_dns_zone_group_name             = optional(string, "default")
     private_dns_zone_resource_ids           = optional(set(string), [])
     application_security_group_associations = optional(map(string), {})
@@ -251,8 +279,7 @@ Default: `true`
 
 ### <a name="input_role_assignment_definition_scope"></a> [role\_assignment\_definition\_scope](#input\_role\_assignment\_definition\_scope)
 
-Description: The scope at which the role assignments should be created.  
-This is typically the resource ID of the subscription of the resource, but could also be the management group for resources deployed there.
+Description: The scope at which the role assignments should be created.
 
 Must be specified when `role_assignments` are defined.
 
@@ -294,13 +321,36 @@ Default: `{}`
 
 The following outputs are exported:
 
+### <a name="output_customer_managed_key_azapi"></a> [customer\_managed\_key\_azapi](#output\_customer\_managed\_key\_azapi)
+
+Description: An object containing the following attributes:
+
+- `identity_client_id` - The client ID of the user-assigned identity. Will be null if no user-assigned identity is provided.
+- `identity_principal_id` - The principal ID of the user-assigned identity. Will be null if no user-assigned identity is provided.
+- `identity_tenant_id` - The tenant ID of the user-assigned identity. Will be null if no user-assigned identity is provided.
+- `key_name` - The name of the key. Will be null if no key is provided.
+- `key_resource_id` - The resource ID of the key, including the version. If the key version is not provided, this will be null.
+- `key_uri` - The URI of the key, including the version. If the key version is not provided, this will be null.
+- `key_vault_uri` - The URI of the key vault.
+- `key_version` - The version of the key. Will be null if no key is provided.
+- `versionless_key_resource_id` - The resource ID of the key, without the version.
+- `versionless_key_uri` - The URI of the key, without the version.
+
 ### <a name="output_diagnostic_settings_azapi"></a> [diagnostic\_settings\_azapi](#output\_diagnostic\_settings\_azapi)
 
-Description: A map of the diagnostic settings resource data for use with azapi.
+Description: A map of diagnostic settings for use in azapi\_resource, the value is an object containing the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
 
 ### <a name="output_lock_azapi"></a> [lock\_azapi](#output\_lock\_azapi)
 
-Description: The lock data for the azapi\_resource.
+Description: An object for use in azapi\_resource with the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
 
 ### <a name="output_managed_identities_azapi"></a> [managed\_identities\_azapi](#output\_managed\_identities\_azapi)
 
@@ -312,15 +362,28 @@ Value is an object with the following attributes:
 
 ### <a name="output_private_dns_zone_groups_azapi"></a> [private\_dns\_zone\_groups\_azapi](#output\_private\_dns\_zone\_groups\_azapi)
 
-Description: Private DNS zone groups for the azapi\_resource.
+Description: A map of private DNS zone groups for use with azapi\_resource, the value is an object containing the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
 
 ### <a name="output_private_endpoints_azapi"></a> [private\_endpoints\_azapi](#output\_private\_endpoints\_azapi)
 
-Description: Private endpoints for the azapi\_resource.
+Description: A map of private endpoints for use with azapi\_resource, the value is an object containing the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
+- `tags` - The tags of the resource.
 
 ### <a name="output_role_assignments_azapi"></a> [role\_assignments\_azapi](#output\_role\_assignments\_azapi)
 
-Description: A map of the role assignments resource data for use with azapi.
+Description: A map of role assignments for use in azapi\_resource, the value is an object containing the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
 
 ## Modules
 

--- a/avm.tflint.override.hcl
+++ b/avm.tflint.override.hcl
@@ -1,3 +1,8 @@
 rule "required_output_rmfr7" {
   enabled = false
 }
+
+# disabled as we must have subresource name as optional
+rule "private_endpoints" {
+  enabled = false
+}

--- a/avm.tflint_override.hcl
+++ b/avm.tflint_override.hcl
@@ -1,4 +1,0 @@
-# disabled as we must have subresource name as optional
-rule "private_endpoints" {
-  enabled = false
-}

--- a/avm.tflint_override.hcl
+++ b/avm.tflint_override.hcl
@@ -1,0 +1,4 @@
+# disabled as we must have subresource name as optional
+rule "private_endpoints" {
+  enabled = false
+}

--- a/examples/customer-managed-key-azapi/README.md
+++ b/examples/customer-managed-key-azapi/README.md
@@ -13,14 +13,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    http = {
-      source  = "hashicorp/http"
-      version = "~> 2.1"
-    }
-    modtm = {
-      source  = "azure/modtm"
-      version = "~> 0.3"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.5"
@@ -176,10 +168,6 @@ The following requirements are needed by this module:
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
-
-- <a name="requirement_http"></a> [http](#requirement\_http) (~> 2.1)
-
-- <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 

--- a/examples/customer-managed-key-azapi/README.md
+++ b/examples/customer-managed-key-azapi/README.md
@@ -1,0 +1,245 @@
+<!-- BEGIN_TF_DOCS -->
+# customer managed key example
+
+```hcl
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 2.1"
+    }
+    modtm = {
+      source  = "azure/modtm"
+      version = "~> 0.3"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+data "azapi_client_config" "current" {}
+
+## Section to provide a random Azure region for the resource group
+# This allows us to randomize the region for the resource group.
+module "regions" {
+  source           = "Azure/avm-utl-regions/azurerm"
+  version          = "0.3.0"
+  enable_telemetry = var.enable_telemetry
+}
+
+# This allows us to randomize the region for the resource group.
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+## End of section to provide a random Azure region for the resource group
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.4.2"
+}
+
+# This is required for resource modules
+resource "azapi_resource" "rg" {
+  type                      = "Microsoft.Resources/resourceGroups@2021-04-01"
+  location                  = module.regions.regions[random_integer.region_index.result].name
+  name                      = module.naming.resource_group.name_unique
+  schema_validation_enabled = false
+}
+
+# user-assigned managed identity
+resource "azapi_resource" "umi" {
+  type      = "Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30"
+  location  = azapi_resource.rg.location
+  name      = module.naming.user_assigned_identity.name_unique
+  parent_id = azapi_resource.rg.id
+  response_export_values = [
+    "properties.principalId",
+    "properties.clientId",
+  ]
+  schema_validation_enabled = false
+}
+
+# key vault & key
+module "key_vault" {
+  source              = "Azure/avm-res-keyvault-vault/azurerm"
+  version             = "0.10.0"
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azapi_resource.rg.name
+  location            = azapi_resource.rg.location
+  tenant_id           = data.azapi_client_config.current.tenant_id
+  network_acls = {
+    default_action = "Allow"
+  }
+  role_assignments = {
+    admin = {
+      principal_id               = data.azapi_client_config.current.object_id
+      role_definition_id_or_name = "Key Vault Administrator"
+      principal_type             = "User"
+    }
+  }
+  keys = {
+    cmk = {
+      name     = "cmk"
+      key_type = "RSA"
+      key_size = 4096
+      key_opts = ["wrapKey", "unwrapKey", "sign", "verify", "encrypt", "decrypt"]
+      enabled  = true
+      role_assignments = {
+        umi = {
+          principal_id               = azapi_resource.umi.output.properties.principalId
+          role_definition_id_or_name = "Key Vault Crypto Service Encryption User"
+          principal_type             = "ServicePrincipal"
+        }
+      }
+    }
+  }
+}
+
+# In ordinary usage, the private_endpoints attribute value would be set to var.private_endpoints.
+# However, in this example, we are using a data source in the same module to retrieve the object id.
+module "avm_interfaces" {
+  source = "../../"
+  customer_managed_key = {
+    key_name              = "cmk"
+    key_vault_resource_id = module.key_vault.resource_id
+    user_assigned_identity = {
+      resource_id = azapi_resource.umi.id
+    }
+  }
+  managed_identities = {
+    system_assigned = false
+    user_assigned_resource_ids = [
+      azapi_resource.umi.id
+    ]
+  }
+}
+
+resource "azapi_resource" "storage" {
+  type = "Microsoft.Storage/storageAccounts@2023-05-01"
+  body = {
+    kind = "StorageV2"
+    properties = {
+      accessTier                   = "Hot"
+      defaultToOAuthAuthentication = true
+      encryption = {
+        identity = {
+          userAssignedIdentity = azapi_resource.umi.id
+        }
+        keyvaultproperties = {
+          keyname     = module.avm_interfaces.customer_managed_key_azapi.key_name
+          keyvaulturi = module.avm_interfaces.customer_managed_key_azapi.key_vault_uri
+          keyversion  = null
+        }
+        keySource = "Microsoft.Keyvault"
+      }
+      minimumTlsVersion        = "TLS1_2"
+      supportsHttpsTrafficOnly = true
+    }
+    sku = {
+      name = "Standard_LRS"
+    }
+  }
+  location  = azapi_resource.rg.location
+  name      = module.naming.storage_account.name_unique
+  parent_id = azapi_resource.rg.id
+
+  identity {
+    type         = module.avm_interfaces.managed_identities_azapi.type
+    identity_ids = module.avm_interfaces.managed_identities_azapi.identity_ids
+  }
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
+
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
+
+- <a name="requirement_http"></a> [http](#requirement\_http) (~> 2.1)
+
+- <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azapi_resource.rg](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.storage](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.umi](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
+- [azapi_client_config.current](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
+
+Description: Enable telemetry for the module
+
+Type: `bool`
+
+Default: `true`
+
+## Outputs
+
+No outputs.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_avm_interfaces"></a> [avm\_interfaces](#module\_avm\_interfaces)
+
+Source: ../../
+
+Version:
+
+### <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault)
+
+Source: Azure/avm-res-keyvault-vault/azurerm
+
+Version: 0.10.0
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: ~> 0.4.2
+
+### <a name="module_regions"></a> [regions](#module\_regions)
+
+Source: Azure/avm-utl-regions/azurerm
+
+Version: 0.3.0
+
+<!-- END_TF_DOCS -->

--- a/examples/customer-managed-key-azapi/_header.md
+++ b/examples/customer-managed-key-azapi/_header.md
@@ -1,0 +1,1 @@
+# customer managed key example

--- a/examples/customer-managed-key-azapi/main.tf
+++ b/examples/customer-managed-key-azapi/main.tf
@@ -9,14 +9,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
-    http = {
-      source  = "hashicorp/http"
-      version = "~> 2.1"
-    }
-    modtm = {
-      source  = "azure/modtm"
-      version = "~> 0.3"
-    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.5"

--- a/examples/customer-managed-key-azapi/main.tf
+++ b/examples/customer-managed-key-azapi/main.tf
@@ -1,0 +1,162 @@
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 2.1"
+    }
+    modtm = {
+      source  = "azure/modtm"
+      version = "~> 0.3"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+data "azapi_client_config" "current" {}
+
+## Section to provide a random Azure region for the resource group
+# This allows us to randomize the region for the resource group.
+module "regions" {
+  source           = "Azure/avm-utl-regions/azurerm"
+  version          = "0.3.0"
+  enable_telemetry = var.enable_telemetry
+}
+
+# This allows us to randomize the region for the resource group.
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+## End of section to provide a random Azure region for the resource group
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.4.2"
+}
+
+# This is required for resource modules
+resource "azapi_resource" "rg" {
+  type                      = "Microsoft.Resources/resourceGroups@2021-04-01"
+  location                  = module.regions.regions[random_integer.region_index.result].name
+  name                      = module.naming.resource_group.name_unique
+  schema_validation_enabled = false
+}
+
+# user-assigned managed identity
+resource "azapi_resource" "umi" {
+  type      = "Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30"
+  location  = azapi_resource.rg.location
+  name      = module.naming.user_assigned_identity.name_unique
+  parent_id = azapi_resource.rg.id
+  response_export_values = [
+    "properties.principalId",
+    "properties.clientId",
+  ]
+  schema_validation_enabled = false
+}
+
+# key vault & key
+module "key_vault" {
+  source              = "Azure/avm-res-keyvault-vault/azurerm"
+  version             = "0.10.0"
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azapi_resource.rg.name
+  location            = azapi_resource.rg.location
+  tenant_id           = data.azapi_client_config.current.tenant_id
+  network_acls = {
+    default_action = "Allow"
+  }
+  role_assignments = {
+    admin = {
+      principal_id               = data.azapi_client_config.current.object_id
+      role_definition_id_or_name = "Key Vault Administrator"
+      principal_type             = "User"
+    }
+  }
+  keys = {
+    cmk = {
+      name     = "cmk"
+      key_type = "RSA"
+      key_size = 4096
+      key_opts = ["wrapKey", "unwrapKey", "sign", "verify", "encrypt", "decrypt"]
+      enabled  = true
+      role_assignments = {
+        umi = {
+          principal_id               = azapi_resource.umi.output.properties.principalId
+          role_definition_id_or_name = "Key Vault Crypto Service Encryption User"
+          principal_type             = "ServicePrincipal"
+        }
+      }
+    }
+  }
+}
+
+# In ordinary usage, the private_endpoints attribute value would be set to var.private_endpoints.
+# However, in this example, we are using a data source in the same module to retrieve the object id.
+module "avm_interfaces" {
+  source = "../../"
+  customer_managed_key = {
+    key_name              = "cmk"
+    key_vault_resource_id = module.key_vault.resource_id
+    user_assigned_identity = {
+      resource_id = azapi_resource.umi.id
+    }
+  }
+  managed_identities = {
+    system_assigned = false
+    user_assigned_resource_ids = [
+      azapi_resource.umi.id
+    ]
+  }
+}
+
+resource "azapi_resource" "storage" {
+  type = "Microsoft.Storage/storageAccounts@2023-05-01"
+  body = {
+    kind = "StorageV2"
+    properties = {
+      accessTier                   = "Hot"
+      defaultToOAuthAuthentication = true
+      encryption = {
+        identity = {
+          userAssignedIdentity = azapi_resource.umi.id
+        }
+        keyvaultproperties = {
+          keyname     = module.avm_interfaces.customer_managed_key_azapi.key_name
+          keyvaulturi = module.avm_interfaces.customer_managed_key_azapi.key_vault_uri
+          keyversion  = null
+        }
+        keySource = "Microsoft.Keyvault"
+      }
+      minimumTlsVersion        = "TLS1_2"
+      supportsHttpsTrafficOnly = true
+    }
+    sku = {
+      name = "Standard_LRS"
+    }
+  }
+  location  = azapi_resource.rg.location
+  name      = module.naming.storage_account.name_unique
+  parent_id = azapi_resource.rg.id
+
+  identity {
+    type         = module.avm_interfaces.managed_identities_azapi.type
+    identity_ids = module.avm_interfaces.managed_identities_azapi.identity_ids
+  }
+}

--- a/examples/customer-managed-key-azapi/variables.tf
+++ b/examples/customer-managed-key-azapi/variables.tf
@@ -1,0 +1,5 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = "Enable telemetry for the module"
+}

--- a/examples/managed-identity-azapi/README.md
+++ b/examples/managed-identity-azapi/README.md
@@ -2,8 +2,6 @@
 # managed identity interface example
 
 ```hcl
-data "azapi_client_config" "current" {}
-
 resource "random_pet" "name" {
   length    = 2
   separator = ""
@@ -62,7 +60,6 @@ The following resources are used by this module:
 - [azapi_resource.rg](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.stg](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) (resource)
 - [random_pet.name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) (resource)
-- [azapi_client_config.current](https://registry.terraform.io/providers/azure/azapi/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/managed-identity-azapi/_header.md
+++ b/examples/managed-identity-azapi/_header.md
@@ -1,0 +1,1 @@
+# managed identity interface example

--- a/examples/managed-identity-azapi/main.tf
+++ b/examples/managed-identity-azapi/main.tf
@@ -1,0 +1,40 @@
+data "azapi_client_config" "current" {}
+
+resource "random_pet" "name" {
+  length    = 2
+  separator = ""
+}
+
+resource "azapi_resource" "rg" {
+  type     = "Microsoft.Resources/resourceGroups@2024-03-01"
+  location = "australiaeast"
+  name     = "rg-${random_pet.name.id}"
+}
+
+resource "azapi_resource" "stg" {
+  type = "Microsoft.Storage/storageAccounts@2023-05-01"
+  body = {
+    sku = {
+      name = "Standard_LRS"
+    }
+    kind = "StorageV2"
+  }
+  location  = azapi_resource.rg.location
+  name      = "stg${random_pet.name.id}1"
+  parent_id = azapi_resource.rg.id
+
+  identity {
+    type         = module.avm_interfaces.managed_identities_azapi.type
+    identity_ids = module.avm_interfaces.managed_identities_azapi.identity_ids
+  }
+}
+
+# In ordinary usage, the private_endpoints attribute value would be set to var.managed_identities.
+# However, in this example, we are using a data source in the same module to retrieve the object id.
+module "avm_interfaces" {
+  source = "../../"
+  managed_identities = {
+    system_assigned            = true
+    user_assigned_resource_ids = []
+  }
+}

--- a/examples/managed-identity-azapi/main.tf
+++ b/examples/managed-identity-azapi/main.tf
@@ -1,5 +1,3 @@
-data "azapi_client_config" "current" {}
-
 resource "random_pet" "name" {
   length    = 2
   separator = ""

--- a/examples/managed-identity-azapi/terraform.tf
+++ b/examples/managed-identity-azapi/terraform.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~> 1.9"
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}

--- a/examples/role-assignments-azapi/main.tf
+++ b/examples/role-assignments-azapi/main.tf
@@ -17,11 +17,10 @@ module "avm_interfaces" {
     example = {
       principal_id               = data.azapi_client_config.current.object_id
       role_definition_id_or_name = "Storage Blob Data Owner"
-      scope                      = azapi_resource.rg.id
       principal_type             = "User"
     }
   }
-  role_assignment_definition_scope = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  role_assignment_definition_scope = azapi_resource.rg.id
 }
 
 data "azapi_client_config" "current" {}

--- a/locals.customer_managed_key.tf
+++ b/locals.customer_managed_key.tf
@@ -1,0 +1,12 @@
+locals {
+  customer_managed_key_identity_client_id          = try(data.azapi_resource.customer_managed_key_identity[0].output.properties.clientId, null)
+  customer_managed_key_identity_principal_id       = try(data.azapi_resource.customer_managed_key_identity[0].output.properties.principalId, null)
+  customer_managed_key_identity_tenant_id          = try(data.azapi_resource.customer_managed_key_identity[0].output.properties.tenantId, null)
+  customer_managed_key_key_name                    = var.customer_managed_key != null ? var.customer_managed_key.key_name : null
+  customer_managed_key_key_resource_id             = var.customer_managed_key != null ? var.customer_managed_key.key_version != null ? "${var.customer_managed_key.key_vault_resource_id}/keys/${var.customer_managed_key.key_name}/versions/${var.customer_managed_key.key_version}" : null : null
+  customer_managed_key_key_uri                     = var.customer_managed_key != null ? var.customer_managed_key.key_version != null ? "${local.customer_managed_key_versionless_key_uri}/${lookup(var.customer_managed_key, "key_version", "")}" : null : null
+  customer_managed_key_key_vault_uri               = var.customer_managed_key != null ? "https://${basename(var.customer_managed_key.key_vault_resource_id)}.${var.customer_managed_key_key_vault_domain}" : null
+  customer_managed_key_key_version                 = var.customer_managed_key != null ? lookup(var.customer_managed_key, "key_version", null) : null
+  customer_managed_key_versionless_key_resource_id = var.customer_managed_key != null ? "${var.customer_managed_key.key_vault_resource_id}/keys/${var.customer_managed_key.key_name}" : null
+  customer_managed_key_versionless_key_uri         = var.customer_managed_key != null ? "${local.customer_managed_key_key_vault_uri}/keys/${var.customer_managed_key.key_name}" : null
+}

--- a/locals.managed_identity.tf
+++ b/locals.managed_identity.tf
@@ -1,10 +1,10 @@
 locals {
-  managed_identities_system_assigned = var.managed_identities.system_assigned ? "SystemAssigned" : null
-  managed_identities_user_assigned   = length(var.managed_identities.user_assigned_resource_ids) > 0 ? "UserAssigned" : null
-  managed_identities_type_list       = compact([local.managed_identities_system_assigned, local.managed_identities_user_assigned])
-  managed_identities_type            = length(local.managed_identities_type_list) > 0 ? join(", ", local.managed_identities_type_list) : null
   managed_identities = local.managed_identities_system_assigned != null || local.managed_identities_user_assigned != null ? {
     type         = local.managed_identities_type
     identity_ids = var.managed_identities.user_assigned_resource_ids
   } : null
+  managed_identities_system_assigned = var.managed_identities.system_assigned ? "SystemAssigned" : null
+  managed_identities_type            = length(local.managed_identities_type_list) > 0 ? join(", ", local.managed_identities_type_list) : null
+  managed_identities_type_list       = compact([local.managed_identities_system_assigned, local.managed_identities_user_assigned])
+  managed_identities_user_assigned   = length(var.managed_identities.user_assigned_resource_ids) > 0 ? "UserAssigned" : null
 }

--- a/locals.managed_identity.tf
+++ b/locals.managed_identity.tf
@@ -1,6 +1,10 @@
 locals {
-  managed_identities = {
-    type         = var.managed_identities.system_assigned && length(var.managed_identities.user_assigned_resource_ids) > 0 ? "SystemAssigned, UserAssigned" : length(var.managed_identities.user_assigned_resource_ids) > 0 ? "UserAssigned" : "SystemAssigned"
+  managed_identities_system_assigned = var.managed_identities.system_assigned ? "SystemAssigned" : null
+  managed_identities_user_assigned   = length(var.managed_identities.user_assigned_resource_ids) > 0 ? "UserAssigned" : null
+  managed_identities_type_list       = compact([local.managed_identities_system_assigned, local.managed_identities_user_assigned])
+  managed_identities_type            = length(local.managed_identities_type_list) > 0 ? join(", ", local.managed_identities_type_list) : null
+  managed_identities = local.managed_identities_system_assigned != null || local.managed_identities_user_assigned != null ? {
+    type         = local.managed_identities_type
     identity_ids = var.managed_identities.user_assigned_resource_ids
-  }
+  } : null
 }

--- a/locals.private_endpoints.tf
+++ b/locals.private_endpoints.tf
@@ -55,7 +55,7 @@ locals {
               name = v.private_service_connection_name != null ? v.private_service_connection_name : local.psc_computed_name[k]
               properties = {
                 privateLinkServiceId = var.private_endpoints_scope
-                groupIds             = [v.subresource_name]
+                groupIds             = v.subresource_name != null ? [v.subresource_name] : null
               }
             }
           ]

--- a/locals.role_assignments.tf
+++ b/locals.role_assignments.tf
@@ -29,9 +29,10 @@ locals {
     )
   }
   # Take the output from the data source and create a map of role_name to resource id.
-  role_assignments_role_name_to_resource_id = var.role_assignment_definition_lookup_enabled ? {
+  role_assignments_role_name_to_resource_id = var.role_assignment_definition_lookup_enabled && length(var.role_assignments) ? {
     for res in data.azapi_resource_list.role_definitions[0].output.results : res.role_name => res.id
   } : {}
+
   # The type and api version of the role assignments resource.
   role_assignments_type = "Microsoft.Authorization/roleAssignments@2022-04-01"
 }

--- a/locals.role_assignments.tf
+++ b/locals.role_assignments.tf
@@ -32,7 +32,6 @@ locals {
   role_assignments_role_name_to_resource_id = var.role_assignment_definition_lookup_enabled && length(var.role_assignments) > 0 ? {
     for res in data.azapi_resource_list.role_definitions[0].output.results : res.role_name => res.id
   } : {}
-
   # The type and api version of the role assignments resource.
   role_assignments_type = "Microsoft.Authorization/roleAssignments@2022-04-01"
 }

--- a/locals.role_assignments.tf
+++ b/locals.role_assignments.tf
@@ -29,7 +29,7 @@ locals {
     )
   }
   # Take the output from the data source and create a map of role_name to resource id.
-  role_assignments_role_name_to_resource_id = var.role_assignment_definition_lookup_enabled && length(var.role_assignments) ? {
+  role_assignments_role_name_to_resource_id = var.role_assignment_definition_lookup_enabled && length(var.role_assignments) > 0 ? {
     for res in data.azapi_resource_list.role_definitions[0].output.results : res.role_name => res.id
   } : {}
 

--- a/main.customer_managed_key.tf
+++ b/main.customer_managed_key.tf
@@ -1,0 +1,11 @@
+data "azapi_resource" "customer_managed_key_identity" {
+  count = var.customer_managed_key == null ? 0 : var.customer_managed_key.user_assigned_identity == null ? 0 : 1
+
+  type        = "Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31"
+  resource_id = var.customer_managed_key.user_assigned_identity.resource_id
+  response_export_values = [
+    "properties.clientId",
+    "properties.principalId",
+    "properties.tenantId",
+  ]
+}

--- a/main.role_assignments.tf
+++ b/main.role_assignments.tf
@@ -1,7 +1,7 @@
 # This resource allows us to look up role definitions by role name.
 # The AzureRM provider does this already so we are replicating this functionality here to benefit AzAPI users.
 data "azapi_resource_list" "role_definitions" {
-  count = var.role_assignment_definition_lookup_enabled && length(var.role_assignment_definition_scope) > 0 ? 1 : 0
+  count = var.role_assignment_definition_lookup_enabled && length(var.role_assignments) > 0 ? 1 : 0
 
   parent_id = var.role_assignment_definition_scope == null ? "/" : var.role_assignment_definition_scope
   type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"

--- a/main.role_assignments.tf
+++ b/main.role_assignments.tf
@@ -3,7 +3,7 @@
 data "azapi_resource_list" "role_definitions" {
   count = var.role_assignment_definition_lookup_enabled && length(var.role_assignments) > 0 ? 1 : 0
 
-  parent_id = var.role_assignment_definition_scope == null ? "/" : var.role_assignment_definition_scope
+  parent_id = var.role_assignment_definition_scope
   type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"
   response_export_values = {
     results = "value[].{id: id, role_name: properties.roleName}"

--- a/main.role_assignments.tf
+++ b/main.role_assignments.tf
@@ -1,7 +1,7 @@
 # This resource allows us to look up role definitions by role name.
 # The AzureRM provider does this already so we are replicating this functionality here to benefit AzAPI users.
 data "azapi_resource_list" "role_definitions" {
-  count = var.role_assignment_definition_lookup_enabled ? 1 : 0
+  count = var.role_assignment_definition_lookup_enabled && length(var.role_assignment_definition_scope) > 0 ? 1 : 0
 
   parent_id = var.role_assignment_definition_scope == null ? "/" : var.role_assignment_definition_scope
   type      = "Microsoft.Authorization/roleDefinitions@2022-04-01"

--- a/outputs.customer_managed_key.tf
+++ b/outputs.customer_managed_key.tf
@@ -1,0 +1,28 @@
+output "customer_managed_key_azapi" {
+  value = {
+    identity_client_id          = local.customer_managed_key_identity_client_id
+    identity_principal_id       = local.customer_managed_key_identity_principal_id
+    identity_tenant_id          = local.customer_managed_key_identity_tenant_id
+    key_name                    = local.customer_managed_key_key_name
+    key_resource_id             = local.customer_managed_key_key_resource_id
+    key_uri                     = local.customer_managed_key_key_uri
+    key_vault_uri               = local.customer_managed_key_key_vault_uri
+    key_version                 = local.customer_managed_key_key_version
+    versionless_key_resource_id = local.customer_managed_key_versionless_key_resource_id
+    versionless_key_uri         = local.customer_managed_key_versionless_key_uri
+  }
+  description = <<DESCRIPTION
+An object containing the following attributes:
+
+- `identity_client_id` - The client ID of the user-assigned identity. Will be null if no user-assigned identity is provided.
+- `identity_principal_id` - The principal ID of the user-assigned identity. Will be null if no user-assigned identity is provided.
+- `identity_tenant_id` - The tenant ID of the user-assigned identity. Will be null if no user-assigned identity is provided.
+- `key_name` - The name of the key. Will be null if no key is provided.
+- `key_resource_id` - The resource ID of the key, including the version. If the key version is not provided, this will be null.
+- `key_uri` - The URI of the key, including the version. If the key version is not provided, this will be null.
+- `key_vault_uri` - The URI of the key vault.
+- `key_version` - The version of the key. Will be null if no key is provided.
+- `versionless_key_resource_id` - The resource ID of the key, without the version.
+- `versionless_key_uri` - The URI of the key, without the version.
+DESCRIPTION
+}

--- a/outputs.diagnostic_settings.tf
+++ b/outputs.diagnostic_settings.tf
@@ -1,4 +1,10 @@
 output "diagnostic_settings_azapi" {
-  description = "A map of the diagnostic settings resource data for use with azapi."
   value       = local.diagnostic_settings_azapi
+  description = <<DESCRIPTION
+A map of diagnostic settings for use in azapi_resource, the value is an object containing the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
+DESCRIPTION
 }

--- a/outputs.lock.tf
+++ b/outputs.lock.tf
@@ -1,4 +1,10 @@
 output "lock_azapi" {
   value       = local.lock_azapi
-  description = "The lock data for the azapi_resource."
+  description = <<DESCRIPTION
+An object for use in azapi_resource with the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
+DESCRIPTION
 }

--- a/outputs.private_endpoints.tf
+++ b/outputs.private_endpoints.tf
@@ -1,9 +1,22 @@
 output "private_endpoints_azapi" {
   value       = local.private_endpoints
-  description = "Private endpoints for the azapi_resource."
+  description = <<DESCRIPTION
+A map of private endpoints for use with azapi_resource, the value is an object containing the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
+- `tags` - The tags of the resource.
+DESCRIPTION
 }
 
 output "private_dns_zone_groups_azapi" {
   value       = local.private_dns_zone_groups
-  description = "Private DNS zone groups for the azapi_resource."
+  description = <<DESCRIPTION
+A map of private DNS zone groups for use with azapi_resource, the value is an object containing the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
+DESCRIPTION
 }

--- a/outputs.role_assignments.tf
+++ b/outputs.role_assignments.tf
@@ -1,4 +1,10 @@
 output "role_assignments_azapi" {
   value       = local.role_assignments_azapi
-  description = "A map of the role assignments resource data for use with azapi."
+  description = <<DESCRIPTION
+A map of role assignments for use in azapi_resource, the value is an object containing the following attributes:
+
+- `type` - The type of the resource.
+- `name` - The name of the resource.
+- `body` - The body of the resource.
+DESCRIPTION
 }

--- a/tests/unit/managed_identities.tftest.hcl
+++ b/tests/unit/managed_identities.tftest.hcl
@@ -69,9 +69,22 @@ run "system_user_assigned" {
 
   variables {
     managed_identities = {
+      system_assigned = true
       user_assigned_resource_ids = [
         "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1",
       ]
     }
+  }
+
+  assert {
+    error_message = "Managed identity type should be SystemAssigned, UserAssigned."
+    condition     = output.managed_identities_azapi.type == "SystemAssigned, UserAssigned"
+  }
+
+  assert {
+    error_message = "Managed identity user assigned identity ids should match."
+    condition = output.managed_identities_azapi.identity_ids == toset([
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1",
+    ])
   }
 }

--- a/tests/unit/managed_identities.tftest.hcl
+++ b/tests/unit/managed_identities.tftest.hcl
@@ -1,0 +1,77 @@
+mock_provider "azapi" {
+  mock_data "azapi_client_config" {
+    defaults = {
+      subscription_id = "00000000-0000-0000-0000-000000000000"
+      tenant_id       = "00000000-0000-0000-0000-000000000000"
+    }
+
+  }
+}
+
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+run "no_input" {
+  command = apply
+
+  assert {
+    error_message = "Managed identity output should be null."
+    condition     = output.managed_identities_azapi == null
+  }
+}
+
+run "system_assigned" {
+  command = apply
+
+  variables {
+    managed_identities = {
+      system_assigned = true
+    }
+  }
+
+  assert {
+    error_message = "Managed identity type should be SystemAssigned."
+    condition     = output.managed_identities_azapi.type == "SystemAssigned"
+  }
+
+  assert {
+    error_message = "Managed identity user assigned identity ids should be empty."
+    condition     = length(output.managed_identities_azapi.identity_ids) == 0
+  }
+}
+
+run "user_assigned" {
+  command = apply
+
+  variables {
+    managed_identities = {
+      user_assigned_resource_ids = [
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1",
+      ]
+    }
+  }
+
+  assert {
+    error_message = "Managed identity type should be UserAssigned."
+    condition     = output.managed_identities_azapi.type == "UserAssigned"
+  }
+
+  assert {
+    error_message = "Managed identity user assigned identity ids should match."
+    condition = output.managed_identities_azapi.identity_ids == toset([
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1",
+    ])
+  }
+}
+
+run "system_user_assigned" {
+  command = apply
+
+  variables {
+    managed_identities = {
+      user_assigned_resource_ids = [
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1",
+      ]
+    }
+  }
+}

--- a/variables.customer_managed_key.tf
+++ b/variables.customer_managed_key.tf
@@ -7,7 +7,16 @@ variable "customer_managed_key" {
       resource_id = string
     }), null)
   })
-  default = null
+  default     = null
+  description = <<DESCRIPTION
+An object containing the following attributes:
+
+- `key_vault_resource_id` - The resource ID of the key vault.
+- `key_name` - The name of the key.
+- `key_version` - (Optional) The version of the key. If not provided, the latest version will be used.
+- `user_assigned_identity` - (Optional) An object containing the resource ID of the user assigned identity.
+  - `resource_id` - The resource ID of the user assigned identity.
+DESCRIPTION
 }
 
 variable "customer_managed_key_key_vault_domain" {

--- a/variables.customer_managed_key.tf
+++ b/variables.customer_managed_key.tf
@@ -1,0 +1,18 @@
+variable "customer_managed_key" {
+  type = object({
+    key_vault_resource_id = string
+    key_name              = string
+    key_version           = optional(string, null)
+    user_assigned_identity = optional(object({
+      resource_id = string
+    }), null)
+  })
+  default = null
+}
+
+variable "customer_managed_key_key_vault_domain" {
+  type        = string
+  default     = "vault.azure.net"
+  nullable    = false
+  description = "The domain name for the key vault. Default is `vault.azure.net`."
+}

--- a/variables.private_endpoints.tf
+++ b/variables.private_endpoints.tf
@@ -17,7 +17,7 @@ variable "private_endpoints" {
     }), null)
     tags                                    = optional(map(string), null)
     subnet_resource_id                      = string
-    subresource_name                        = string # NOTE: `subresource_name` can be excluded if the resource does not support multiple sub resource types (e.g. storage account supports blob, queue, etc)
+    subresource_name                        = optional(string, null)
     private_dns_zone_group_name             = optional(string, "default")
     private_dns_zone_resource_ids           = optional(set(string), [])
     application_security_group_associations = optional(map(string), {})

--- a/variables.role_assignments.tf
+++ b/variables.role_assignments.tf
@@ -29,7 +29,6 @@ variable "role_assignment_definition_scope" {
   type        = string
   description = <<DESCRIPTION
 The scope at which the role assignments should be created.
-This is typically the resource ID of the subscription of the resource, but could also be the management group for resources deployed there.
 
 Must be specified when `role_assignments` are defined.
 DESCRIPTION

--- a/variables.role_assignments.tf
+++ b/variables.role_assignments.tf
@@ -28,7 +28,7 @@ DESCRIPTION
 variable "role_assignment_definition_scope" {
   type        = string
   description = <<DESCRIPTION
-The scope at which the role assignments should be created.
+The scope at which the role assignments should be created. Used to look up role definitions by role name.
 
 Must be specified when `role_assignments` are defined.
 DESCRIPTION


### PR DESCRIPTION
Adds:

- customer managed key support, with example
- better output descriptions
- only lookup role definition names if there are role assignments