### PR TITLE
fix: ensure role assignment type is set for azapi and private endpoints

### DIFF
--- a/locals.role_assignments.tf
+++ b/locals.role_assignments.tf
@@ -3,6 +3,7 @@ locals {
   role_assignments_azapi = {
     for k, v in var.role_assignments : k => {
       name = coalesce(v.role_assignment_name, random_uuid.role_assignment_name[k].result)
+      type = local.role_assignments_type
       body = {
         properties = {
           principalId                        = v.principal_id
@@ -23,6 +24,7 @@ locals {
       pe_key         = v.pe_key
       assignment_key = v.assignment_key
       name           = random_uuid.role_assignment_name_private_endpoint[k].result
+      type = local.role_assignments_type
       body = {
         properties = {
           principalId                        = var.private_endpoints[v.pe_key].role_assignments[v.assignment_key].principal_id


### PR DESCRIPTION
This pull request introduces a minor update to the `locals.role_assignments.tf` file by adding the `type` field to both the standard and private endpoint role assignment definitions. This ensures that each role assignment now explicitly includes its type, likely for improved consistency or downstream processing.

- **Role assignment structure update:**
  - Added the `type` field (set to `local.role_assignments_type`) to the main `role_assignments_azapi` and `role_assignments_private_endpoint_azapi` local values. [[1]](diffhunk://#diff-36ae2ad1a1bbad5a3422bbefde3b47dcac43c75cd88f4031717ca69ea8a17045R6) [[2]](diffhunk://#diff-36ae2ad1a1bbad5a3422bbefde3b47dcac43c75cd88f4031717ca69ea8a17045R27)