### PR TITLE
Fix/role assignment

### DIFF
--- a/locals.role_assignments.tf
+++ b/locals.role_assignments.tf
@@ -3,6 +3,7 @@ locals {
   role_assignments_azapi = {
     for k, v in var.role_assignments : k => {
       name = coalesce(v.role_assignment_name, random_uuid.role_assignment_name[k].result)
+      type = local.role_assignments_type
       body = {
         properties = {
           principalId                        = v.principal_id
@@ -23,6 +24,7 @@ locals {
       pe_key         = v.pe_key
       assignment_key = v.assignment_key
       name           = random_uuid.role_assignment_name_private_endpoint[k].result
+      type = local.role_assignments_type
       body = {
         properties = {
           principalId                        = var.private_endpoints[v.pe_key].role_assignments[v.assignment_key].principal_id

--- a/locals.role_assignments.tf
+++ b/locals.role_assignments.tf
@@ -17,6 +17,22 @@ locals {
       }
     }
   }
+
+  # Merge user-supplied configuration with Azure-returned values to prevent drift.
+  # Azure automatically infers principalType and returns fully qualified roleDefinitionId paths.
+  # We prefer user-supplied values where provided, but accept Azure's values for drift-prone fields.
+  role_assignments_merged = {
+    for k, v in data.azapi_resource.role_assignments : k => {
+      principalId                        = local.role_assignments_azapi[k].body.properties.principalId
+      roleDefinitionId                   = v.output.properties.roleDefinitionId # Use Azure's normalized path
+      conditionVersion                   = local.role_assignments_azapi[k].body.properties.conditionVersion
+      condition                          = local.role_assignments_azapi[k].body.properties.condition
+      description                        = local.role_assignments_azapi[k].body.properties.description
+      principalType                      = v.output.properties.principalType # Use Azure's inferred value
+      delegatedManagedIdentityResourceId = local.role_assignments_azapi[k].body.properties.delegatedManagedIdentityResourceId
+    }
+  }
+
   # The role assignments for private endpoints.
   # We reference the variable to avoid cycle errors.
   role_assignments_private_endpoint_azapi = {
@@ -24,7 +40,7 @@ locals {
       pe_key         = v.pe_key
       assignment_key = v.assignment_key
       name           = random_uuid.role_assignment_name_private_endpoint[k].result
-      type = local.role_assignments_type
+      type           = local.role_assignments_type
       body = {
         properties = {
           principalId                        = var.private_endpoints[v.pe_key].role_assignments[v.assignment_key].principal_id
@@ -38,6 +54,21 @@ locals {
       }
     }
   }
+
+  # Merge user-supplied configuration with Azure-returned values for private endpoint role assignments.
+  # Same drift prevention logic as above, applied to private endpoint role assignments.
+  role_assignments_private_endpoint_merged = {
+    for k, v in data.azapi_resource.role_assignments_private_endpoint : k => {
+      principalId                        = local.role_assignments_private_endpoint_azapi[k].body.properties.principalId
+      roleDefinitionId                   = v.output.properties.roleDefinitionId # Use Azure's normalized path
+      conditionVersion                   = local.role_assignments_private_endpoint_azapi[k].body.properties.conditionVersion
+      condition                          = local.role_assignments_private_endpoint_azapi[k].body.properties.condition
+      description                        = local.role_assignments_private_endpoint_azapi[k].body.properties.description
+      principalType                      = v.output.properties.principalType # Use Azure's inferred value
+      delegatedManagedIdentityResourceId = local.role_assignments_private_endpoint_azapi[k].body.properties.delegatedManagedIdentityResourceId
+    }
+  }
+
   # Create a flattened map of role assignments for private endpoints.
   # Only include keys to avoid cycle errors.
   role_assignments_private_endpoint_azapi_keys_only = {


### PR DESCRIPTION
This pull request introduces a robust three-step process for managing Azure role assignments and private endpoint role assignments in Terraform, addressing configuration drift caused by Azure's automatic inference and normalization of certain properties. The update ensures that user-supplied configuration is merged with Azure-returned values, and drift-prone fields are handled correctly to maintain idempotency and prevent unnecessary updates.

Key improvements and features:

**Drift Prevention and State Management:**

* Added a three-step resource lifecycle for both standard and private endpoint role assignments:
  1. Create resources with `ignore_changes` for drift-prone fields (`principalType`, `roleDefinitionId`).
  2. Read the actual state from Azure after creation to capture Azure-inferred values.
  3. Update resources by merging user configuration with Azure's returned state to eliminate drift. [[1]](diffhunk://#diff-3fdd1b68fe243ba12bf632d03fa9a930a4c92685f2772c26e0f37048847a7cebR26-R28) [[2]](diffhunk://#diff-3fdd1b68fe243ba12bf632d03fa9a930a4c92685f2772c26e0f37048847a7cebR40-R74) [[3]](diffhunk://#diff-3fdd1b68fe243ba12bf632d03fa9a930a4c92685f2772c26e0f37048847a7cebR86-R115)

**Locals and Merging Logic:**

* Introduced new locals (`role_assignments_merged`, `role_assignments_private_endpoint_merged`) to combine user-supplied and Azure-returned values, preferring user configuration where possible while accepting Azure's values for drift-prone fields. [[1]](diffhunk://#diff-36ae2ad1a1bbad5a3422bbefde3b47dcac43c75cd88f4031717ca69ea8a17045R20-R43) [[2]](diffhunk://#diff-36ae2ad1a1bbad5a3422bbefde3b47dcac43c75cd88f4031717ca69ea8a17045R57-R71)
* Updated locals to include the `type` field for both standard and private endpoint role assignments, ensuring consistency in resource definitions.

These changes significantly improve the stability and reliability of Terraform-managed Azure role assignments by preventing configuration drift and unnecessary updates.