### PR TITLE
fix: private endpoint variables missing member_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Description:   A map of private endpoints to create. The map key is deliberately
   - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. If not specified the platform will create one. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
     - `name` - The name of the IP configuration.
     - `private_ip_address` - The private IP address of the IP configuration.
+    - `member_name` - The private IP configuration member name.
 
 Type:
 
@@ -302,6 +303,7 @@ map(object({
     ip_configurations = optional(map(object({
       name               = string
       private_ip_address = string
+      member_name        = optional(string)
     })), {})
   }))
 ```

--- a/examples/customer-managed-key-azapi/README.md
+++ b/examples/customer-managed-key-azapi/README.md
@@ -47,7 +47,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "~> 0.4.2"
+  version = "0.4.2"
 }
 
 # This is required for resource modules
@@ -238,7 +238,7 @@ Version: 0.10.0
 
 Source: Azure/naming/azurerm
 
-Version: ~> 0.4.2
+Version: 0.4.2
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 

--- a/examples/customer-managed-key-azapi/main.tf
+++ b/examples/customer-managed-key-azapi/main.tf
@@ -42,7 +42,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "~> 0.4.2"
+  version = "0.4.2"
 }
 
 # This is required for resource modules

--- a/locals.private_endpoints.tf
+++ b/locals.private_endpoints.tf
@@ -46,7 +46,7 @@ locals {
               properties = {
                 privateIPAddress = lookup(ip_configuration, "private_ip_address", null)
                 groupId          = v.subresource_name
-                memberName       = lookup(ip_configuration, "member_name", "default")
+                memberName       = coalesce(ip_configuration.member_name, "default")
               }
             }
           ] : []

--- a/variables.private_endpoints.tf
+++ b/variables.private_endpoints.tf
@@ -61,7 +61,7 @@ variable "private_endpoints" {
   - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. If not specified the platform will create one. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
     - `name` - The name of the IP configuration.
     - `private_ip_address` - The private IP address of the IP configuration.
-    - `member_name` - The private IP configuarion member name
+    - `member_name` - The private IP configuration member name.
   DESCRIPTION
   nullable    = false
 

--- a/variables.private_endpoints.tf
+++ b/variables.private_endpoints.tf
@@ -28,6 +28,7 @@ variable "private_endpoints" {
     ip_configurations = optional(map(object({
       name               = string
       private_ip_address = string
+      member_name        = string
     })), {})
   }))
   default     = {}
@@ -60,6 +61,7 @@ variable "private_endpoints" {
   - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. If not specified the platform will create one. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
     - `name` - The name of the IP configuration.
     - `private_ip_address` - The private IP address of the IP configuration.
+    - `member_name` - The private IP configuarion member name
   DESCRIPTION
   nullable    = false
 

--- a/variables.private_endpoints.tf
+++ b/variables.private_endpoints.tf
@@ -28,7 +28,7 @@ variable "private_endpoints" {
     ip_configurations = optional(map(object({
       name               = string
       private_ip_address = string
-      member_name        = string
+      member_name        = optional(string)
     })), {})
   }))
   default     = {}


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Added 'member_name' field to IP configurations.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
